### PR TITLE
remove sftp from ansible managed sshd conf

### DIFF
--- a/vars/Ubuntu_22.yml
+++ b/vars/Ubuntu_22.yml
@@ -15,7 +15,6 @@ __sshd_defaults:
   KbdInteractiveAuthentication: false
   UsePAM: true
   AcceptEnv: LANG LC_*
-  Subsystem: "sftp  /usr/lib/openssh/sftp-server"
 
 __sshd_runtime_directory: /run/sshd
 


### PR DESCRIPTION
I deleted the Sftp configuration from vars for Ubuntu 22, because in new versions of the ssh package it is by default, which causes a configuration conflict and the service crashes.